### PR TITLE
Make the workspace instance name consistent and predictable

### DIFF
--- a/datascrubber/__init__.py
+++ b/datascrubber/__init__.py
@@ -20,12 +20,11 @@ class ScrubWorkspaceInstance:
         self.password = "{0:x}".format(random.getrandbits(41 * 4))
         self.source_instance = self.snapshot_finder.get_source_instance()
 
-        self.instance_identifier = "scrubber-workspace-{0}-{1}-{2}".format(
+        self.instance_identifier = "scrubber-{0}-{1}".format(
             self.source_instance['Engine'],
             hashlib.sha256(
                 self.source_instance['DBInstanceIdentifier'].encode()
-            ).hexdigest()[0:8],
-            datetime.now().strftime("%Y%m%d%H%M%S")
+            ).hexdigest()[0:12]
         )
         self.final_snapshot_identifier = "scrubbed-{0}-{1}".format(
             self.source_instance['DBInstanceIdentifier'],


### PR DESCRIPTION
Drop the timestamps from the workspaces' instance identifiers.

The instance identifier is used to select the snapshots on the import side, and having a timestamp in there adds complexity.

Continue to use a hash of the source instance identifier; this guarantees we don't overflow the (relatively short) instance identifier size limit of 63 chars.

Generated snapshots still include timestamp information.