### PR TITLE
Don't submit Icinga check if icinga_host not specified

### DIFF
--- a/datascrubber/cli.py
+++ b/datascrubber/cli.py
@@ -345,10 +345,14 @@ def worker(dbms, hostname=None, instance=None, snapshot=None, region=None, targe
                     "in case sensitive data remains.",
                     task, err
                 )
-                submit_passive_icinga_check(task, 'CRITICAL', icinga_host, err)
+
+                if icinga_host is not None:
+                    submit_passive_icinga_check(task, 'CRITICAL', icinga_host, err)
+
                 break
 
-            submit_passive_icinga_check(task, 'OK', icinga_host)
+            if icinga_host is not None:
+                submit_passive_icinga_check(task, 'OK', icinga_host)
 
         workspace.cleanup(create_final_snapshot=success)
         if success:


### PR DESCRIPTION
Fix a regression where the script would crash if `--icinga-host` wasn't given.
