### PR TITLE
Multiple fixes

### DIFF
--- a/datascrubber/__init__.py
+++ b/datascrubber/__init__.py
@@ -18,18 +18,19 @@ class ScrubWorkspaceInstance:
         self.snapshot_finder = snapshot_finder
         self.timeout = timeout
         self.password = "{0:x}".format(random.getrandbits(41 * 4))
-        self.source_instance = self.snapshot_finder.get_source_instance()
 
+        self.source_snapshot = self.snapshot_finder.get_snapshot()
         self.instance_identifier = "scrubber-{0}-{1}".format(
-            self.source_instance['Engine'],
+            self.source_snapshot['Engine'],
             hashlib.sha256(
-                self.source_instance['DBInstanceIdentifier'].encode()
+                self.source_snapshot['DBInstanceIdentifier'].encode()
             ).hexdigest()[0:12]
         )
         self.final_snapshot_identifier = "scrubbed-{0}-{1}".format(
-            self.source_instance['DBInstanceIdentifier'],
+            self.source_snapshot['DBInstanceIdentifier'],
             timestamp.strftime("%Y-%m-%d-%H-%M")
         )
+        self.source_instance = self.snapshot_finder.get_source_instance()
 
         self.instance = None
         self.deleted = False
@@ -263,16 +264,35 @@ class RdsSnapshotFinder:
         if dbms not in ['mysql', 'postgresql']:
             raise Exception('dbms must be one of mysql, postgresql')
 
-        self.dbms = dbms
         self.boto3_session = boto3_session
-        self.hostname = hostname
-        self.rds_endpoint_address = None
-        self.source_instance = None
-        self.source_instance_identifier = source_instance_identifier
-        self.snapshot_identifier = snapshot_identifier
         self.rds_client = self.boto3_session.client('rds')
 
+        self.dbms = dbms
+        self.hostname = hostname
+        self.source_instance_identifier = source_instance_identifier
+        self.snapshot_identifier = snapshot_identifier
+
+        self.rds_endpoint_address = None
+        self.source_instance = None
+        self.snapshot = None
+
         logger.info("Initialised RDS Snapshot Finder for {0}".format(dbms))
+
+    def get_snapshot(self):
+        if self.snapshot is None:
+            snapshot_identifier = self.get_snapshot_identifier()
+
+            response = self.rds_client.describe_db_snapshots(
+                DBSnapshotIdentifier=snapshot_identifier,
+            )
+
+            if len(response['DBSnapshots']) == 0:
+                raise Exception("Snapshot {0} not found".format(snapshot_identifier))
+
+            self.snapshot = response['DBSnapshots'][0]
+            self.source_instance_identifier = self.snapshot['DBInstanceIdentifier']
+
+        return self.snapshot
 
     def get_snapshot_identifier(self):
         if self.snapshot_identifier is None:
@@ -353,12 +373,7 @@ class RdsSnapshotFinder:
 
     def get_hostname(self):
         if self.hostname is None:
-            logger.info(
-                "Using hostname default for %s: '%s'",
-                self.dbms,
-                self.hostname_defaults[self.dbms],
-            )
-            self.hostname = self.hostname_defaults[self.dbms]
+            raise Exception("No hostname provided")
 
         return self.hostname
 

--- a/datascrubber/__init__.py
+++ b/datascrubber/__init__.py
@@ -264,6 +264,9 @@ class RdsSnapshotFinder:
         self.boto3_session = boto3_session
         self.rds_client = self.boto3_session.client('rds')
 
+        if (hostname is None and source_instance_identifier is None and snapshot_identifier is None):
+            raise Exception("One of hostname, source_instance_identifier, snapshot_identifier must be provided")
+
         self.hostname = hostname
         self.source_instance_identifier = source_instance_identifier
         self.snapshot_identifier = snapshot_identifier

--- a/datascrubber/__init__.py
+++ b/datascrubber/__init__.py
@@ -260,14 +260,10 @@ class ScrubWorkspaceInstance:
 class RdsSnapshotFinder:
     rds_domain = dns.name.from_text('rds.amazonaws.com.')
 
-    def __init__(self, dbms, boto3_session, hostname=None, source_instance_identifier=None, snapshot_identifier=None):
-        if dbms not in ['mysql', 'postgresql']:
-            raise Exception('dbms must be one of mysql, postgresql')
-
+    def __init__(self, boto3_session, hostname=None, source_instance_identifier=None, snapshot_identifier=None):
         self.boto3_session = boto3_session
         self.rds_client = self.boto3_session.client('rds')
 
-        self.dbms = dbms
         self.hostname = hostname
         self.source_instance_identifier = source_instance_identifier
         self.snapshot_identifier = snapshot_identifier
@@ -276,7 +272,7 @@ class RdsSnapshotFinder:
         self.source_instance = None
         self.snapshot = None
 
-        logger.info("Initialised RDS Snapshot Finder for {0}".format(dbms))
+        logger.info("Initialised RDS Snapshot Finder")
 
     def get_snapshot(self):
         if self.snapshot is None:

--- a/datascrubber/cli.py
+++ b/datascrubber/cli.py
@@ -317,7 +317,6 @@ def worker(dbms, hostname=None, instance=None, snapshot=None, region=None, targe
         rds_client = session.client('rds')
 
         snapshot_finder = RdsSnapshotFinder(
-            dbms,
             boto3_session=session,
             hostname=hostname,
             source_instance_identifier=instance,

--- a/datascrubber/task_managers/mysql.py
+++ b/datascrubber/task_managers/mysql.py
@@ -1,7 +1,6 @@
 import logging
 import mysql.connector
 import re
-import socket
 import subprocess
 
 import datascrubber.tasks

--- a/datascrubber/task_managers/postgresql.py
+++ b/datascrubber/task_managers/postgresql.py
@@ -1,7 +1,6 @@
 import logging
 import psycopg2
 import re
-import socket
 import subprocess
 
 import datascrubber.tasks


### PR DESCRIPTION
* Fix the use case of calling with an explicit snapshot specification, i.e. not using snapshot auto-discovery from an existing RDS instance.

* Code cleanup:
  * Remove a couple of unused exports
  * The `dbms` parameter to `RdsSnapshotFinder` wasn't being used - remove it
