### PR TITLE
Time-stamp S3 exports

### DIFF
--- a/datascrubber/task_managers/mysql.py
+++ b/datascrubber/task_managers/mysql.py
@@ -3,6 +3,7 @@ import mysql.connector
 import re
 import subprocess
 import shlex
+import time
 
 import datascrubber.tasks
 
@@ -118,7 +119,11 @@ class Mysql:
             self.db_realnames[database],
         ])))
 
-        s3_url = '{0}/{1}.sql.gz'.format(s3_url_prefix, database)
+        s3_url = '{0}/{1}-{2}.sql.gz'.format(
+            s3_url_prefix,
+            time.strftime("%Y-%m-%dT%H:%M:%S"),
+            self.db_realnames[database],
+        )
         s3_command = 'aws s3 cp - {0}'.format(shlex.quote(s3_url))
 
         shell_command = '{0} | gzip | {1}'.format(mysqldump_command, s3_command)

--- a/datascrubber/task_managers/postgresql.py
+++ b/datascrubber/task_managers/postgresql.py
@@ -4,6 +4,7 @@ import re
 import subprocess
 import shlex
 import os
+import time
 
 import datascrubber.tasks
 
@@ -109,7 +110,11 @@ class Postgresql:
             '--dbname={0}'.format(self.db_realnames[database]),
         ])))
 
-        s3_url = '{0}/{1}.sql.gz'.format(s3_url_prefix, database)
+        s3_url = '{0}/{1}-{2}.sql.gz'.format(
+            s3_url_prefix,
+            time.strftime("%Y-%m-%dT%H:%M:%S"),
+            self.db_realnames[database],
+        )
         s3_command = 'aws s3 cp - {0}'.format(shlex.quote(s3_url))
 
         shell_command = '{0} | gzip | {1}'.format(pgdump_command, s3_command)


### PR DESCRIPTION
As requested. Also use the "real" name of the database (with the `_production`) suffix.

This aligns the names in the S3 bucket with what the data-sync tools expect.